### PR TITLE
7.1: commented out page-aliases in public-api-reference.adoc due to build error

### DIFF
--- a/software/modules/ROOT/pages/public-api-reference.adoc
+++ b/software/modules/ROOT/pages/public-api-reference.adoc
@@ -1,7 +1,7 @@
 = Public API reference
 :last_updated: 08/20/2021
 :linkattrs:
-:page-aliases: pinboard-data-api.adoc, metadata-api.adoc, session-api.adoc, user-api.adoc, group-api.adoc, materialization-api.adoc, search-data-api.adoc
+// :page-aliases: pinboard-data-api.adoc, metadata-api.adoc, session-api.adoc, user-api.adoc, group-api.adoc, materialization-api.adoc, search-data-api.adoc
 :experimental:
 
 ThoughtSpot has several public APIs.


### PR DESCRIPTION
Error message in build: 

Error: Page alias cannot reference an existing page: 7.1@Software::pinboard-data-api.adoc (specified as: pinboard-data-api.adoc)
9:54:37 PM:   source: software/modules/ROOT/pages/public-api-reference.adoc in https://github.com/thoughtspot/thoughtspot-docs.git (ref: 7.1)

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>