### PR TITLE
7.1: removal of jdbc logging redirect from jdbc-logging.adoc

### DIFF
--- a/software/modules/ROOT/pages/JDBC-logging.adoc
+++ b/software/modules/ROOT/pages/JDBC-logging.adoc
@@ -1,7 +1,7 @@
 = Enable JDBC logs
 :last-upddated: 06/23/20021
 :experimental:
-:page-aliases: /data-integrate/troubleshooting/JDBC-logging.adoc, JDBC-logging.adoc
+:page-aliases: /data-integrate/troubleshooting/JDBC-logging.adoc
 :linkattrs:
 
 Configure logging parameter strings.


### PR DESCRIPTION
To fix broken build

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>