### PR TITLE
7.1: fix dr-config

### DIFF
--- a/software/modules/ROOT/pages/dr-config.adoc
+++ b/software/modules/ROOT/pages/dr-config.adoc
@@ -160,7 +160,7 @@ If you are unfamiliar with the policy format, see xref:backup-configure-schedule
 +
 By default, newly created policies are automatically enabled.
 
-. Verify the policy using the `tscli backup periodic-config <name>` command.
+. Verify the policy using the `tscli backup-policy show <name>` command.
 +
 Use the `<name>` from the policy you created in the previous step.
 
@@ -169,7 +169,7 @@ Use the `<name>` from the policy you created in the previous step.
 +
 [source]
 ----
-tscli dr-mirror start
+tscli dr-mirror start <mount point> <comma separated ip addresses of secondary cluster> <cluster name> <cluster id>
 ----
 
 . Verify that the cluster has started running in mirror mode


### PR DESCRIPTION
Per Kirsten:
I think not very many people use this, but https://docs.thoughtspot.com/software/7.1/dr-config.html needs some updating.  The command on that page:
tscli backup periodic-config <name>
does not exist.   I'm not sure what this was supposed to be, but I think you can replace it with
tscli backup-policy show <name>
The tscli dr-mirror start command requires parameters and cannot be run as listed in the documentation.  It should instead be
tscli dr-mirror start <mount point> <comma separated ip addresses of secondary cluster> <cluster name> <cluster id>

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>