### PR TITLE
jan cloud: removed broken link from databricks reference article

### DIFF
--- a/cloud/modules/ROOT/pages/connections-databricks-reference.adoc
+++ b/cloud/modules/ROOT/pages/connections-databricks-reference.adoc
@@ -28,5 +28,3 @@ User:: Enter your login email to your Azure account.
 If this does not work, try "`token`".
 Password:: Enter your '`personal access token`' generated in Databricks.
 This is not the password for your Azure account.  For more information, see https://docs.microsoft.com/en-us/azure/databricks/dev-tools/api/latest/authentication#--generate-a-personal-access-token[Generate a personal access token^].
-
-For detailed information on using ThoughtSpot with an Azure Databricks cluster, see https://docs.microsoft.com/en-us/azure/databricks/integrations/bi/thoughtspot[Microsoft Azure ThoughtSpot documentation^].


### PR DESCRIPTION
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>