### PR TITLE
nov cloud: fixed wrong link to azure ad oauth on nov cloud home page

### DIFF
--- a/cloud/modules/ROOT/pages/index.adoc
+++ b/cloud/modules/ROOT/pages/index.adoc
@@ -48,7 +48,7 @@ Find topics for the common types of ThoughtSpot users below.
     </h2>
     <ul>
         <li><a href="https://docs.thoughtspot.com/cloud/ts8.nov.cl/connections">Connections</a></li>
-        <li><img src="_images/snowflake_sm.png" width="20px" alt="more options menu icon" class="inline"><a href="https://docs.thoughtspot.com/cloud/ts8.nov.cl/connections-redshift">Azure AD OAuth <span class="badge badge-new">New!</span></a></li>
+        <li><img src="_images/snowflake_sm.png" width="20px" alt="more options menu icon" class="inline"><a href="https://docs.thoughtspot.com/cloud/ts8.nov.cl/connections-snowflake-azure-ad-oauth">Azure AD OAuth <span class="badge badge-new">New!</span></a></li>
     </ul>
     </div>
       <div class="box">


### PR DESCRIPTION
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>