### PR TITLE
8.2.0.cl: removed aws secrets manager from release notes

### DIFF
--- a/cloud/modules/ROOT/partials/new-features-cloud-release.adoc
+++ b/cloud/modules/ROOT/partials/new-features-cloud-release.adoc
@@ -60,10 +60,6 @@ This feature is in *Beta* and on only for select customers.
 [#8-2-0-cl-data-engineer]
 === For the Data Engineer
 
-[#connections-redshift-aws-secrets-manager]
-AWS Secrets Manager for Redshift connection passwords::
-Amazon Redshift connections now support AWS Secrets Manager for clusters deployed on an AWS EC2 instance. With this feature enabled, you no longer need to enter a password when you create a new Redshift connection. For details, see xref:connections-aws-secrets.adoc[Amazon Secrets Manager]. This feature is disabled by default. To enable it, contact xref:support-contact.adoc[ThoughtSpot Support].
-
 [#connections-flow-data-portal]
 New connection creation flow with data tab redesign::
 If you have the new <<data-tab,redesigned data tab>> enabled, you can see the new Data Workspace page from the *Data* tab in the top navigation bar. To start creating a connection, click *Connections*, then click the connection type you want to create. The new Data Workspace allows you to create a connection without selecting tables or columns.
@@ -89,4 +85,3 @@ This switch involves several external improvements to authentication, including 
 === For the Developer
 
 ThoughtSpot Everywhere:: For information about the new features and enhancements introduced in this release, refer to https://developers.thoughtspot.com/docs/?pageid=whats-new[ThoughtSpot Developer Documentation^].
-


### PR DESCRIPTION
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>