### PR TITLE
8.4.0.sw: tweak to beta labels in rel notes

### DIFF
--- a/software/modules/ROOT/pages/notes.adoc
+++ b/software/modules/ROOT/pages/notes.adoc
@@ -65,19 +65,19 @@ We now support more detailed geographic maps for France. You can now create maps
 === For the Data Engineer
 
 [#data-workspace-beta]
-Data Workspace [.label.label-beta]#Beta#::
+Data Workspace [.badge.badge-update]#Beta#::
 This release redesigns the Data section of the product. The new Data Workspace is still in the same place in the product. To access it, select Data from the top navigation bar. The redesign introduces several new features, such as SQL-based views and SpotApps, and makes the UI more intuitive.
 +
 This feature is in beta and off by default. To enable it, contact {support-url}.
 
 [#sql-views-beta]
-SQL-based views [.label.label-beta]#Beta#::
+SQL-based views  [.badge.badge-update]#Beta#::
 This release introduces beta support for SQL-based views. Users can create views based on custom SQL queries, and use those views as data sources. This type of view has the same functionality as a view based on searching your data.
 +
 This feature is in beta and off by default. It is part of the new <<data-workspace-beta,Data Workspace>>, which is also in beta and off by default. To enable SQL-based views and the new Data Workspace, contact {support-url}.
 
 [#dbt-beta]
-Integration with dbt [.label.label-beta]#Beta#::
+Integration with dbt  [.badge.badge-update]#Beta#::
 ThoughtSpot now offers an integration with dbt. You can provide your existing dbt models and automatically create worksheets in ThoughtSpot that you can use to perform searches on your data.
 +
 This feature is in beta and off by default. It is part of the new <<data-workspace-beta,Data Workspace>>, which is also in beta and off by default. To enable dbt integration and the Data tab redesign, contact {support-url}.


### PR DESCRIPTION
Changed them to update badges with Beta text to match format used in what's new and size of new badges in release notes.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>