### PR TITLE
8.8.0.cl: removed dup page-aliases from copied starburst files

### DIFF
--- a/cloud/modules/ROOT/pages/connections-presto-add.adoc
+++ b/cloud/modules/ROOT/pages/connections-presto-add.adoc
@@ -2,7 +2,7 @@
 :last_updated: 9/21/2020
 :linkattrs:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-add-connection.adoc
+:page-aliases: 
 :experimental:
 :connection: Presto
 

--- a/cloud/modules/ROOT/pages/connections-presto-delete-table-dependencies.adoc
+++ b/cloud/modules/ROOT/pages/connections-presto-delete-table-dependencies.adoc
@@ -2,7 +2,7 @@
 :last_updated: 11/05/2021
 :linkattrs:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-delete-table-dependencies.adoc
+:page-aliases:
 :experimental:
 :connection: Presto
 

--- a/cloud/modules/ROOT/pages/connections-presto-delete-table.adoc
+++ b/cloud/modules/ROOT/pages/connections-presto-delete-table.adoc
@@ -2,7 +2,7 @@
 :last_updated: 9/21/2020
 :linkattrs:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-delete-table.adoc
+:page-aliases:
 :experimental:
 :connection: Presto
 

--- a/cloud/modules/ROOT/pages/connections-presto-delete.adoc
+++ b/cloud/modules/ROOT/pages/connections-presto-delete.adoc
@@ -3,7 +3,7 @@
 :linkattrs:
 :experimental:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-delete-connection.adoc
+:page-aliases:
 :connection: Presto
 
 A connection can be used in multiple data sources or visualizations.

--- a/cloud/modules/ROOT/pages/connections-presto-edit.adoc
+++ b/cloud/modules/ROOT/pages/connections-presto-edit.adoc
@@ -3,7 +3,7 @@
 :linkattrs:
 :experimental:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-edit-connection.adoc
+:page-aliases:
 :description: You can edit a Starburst connection to add tables and columns.
 :connection: presto
 

--- a/cloud/modules/ROOT/pages/connections-presto-reference.adoc
+++ b/cloud/modules/ROOT/pages/connections-presto-reference.adoc
@@ -1,6 +1,6 @@
 = Connection reference for {connection}
 :last_updated: 5/11/2020
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-connection-reference.adoc, /data-integrate/embrace/embrace-starburst-reference.adoc
+:page-aliases:
 :linkattrs:
 :page-layout: default-cloud
 :experimental:

--- a/cloud/modules/ROOT/pages/connections-presto-remap.adoc
+++ b/cloud/modules/ROOT/pages/connections-presto-remap.adoc
@@ -2,7 +2,7 @@
 :last_updated: 9/21/2020
 :linkattrs:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-remap-connection.adoc
+:page-aliases: 
 :experimental:
 :connection: Presto
 

--- a/cloud/modules/ROOT/pages/connections-presto.adoc
+++ b/cloud/modules/ROOT/pages/connections-presto.adoc
@@ -2,7 +2,7 @@
 :last_updated: 11/05/2021
 :linkattrs:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst.adoc
+:page-aliases:
 :experimental:
 :connection: Presto
 :description: You can connect to a Presto database in ThoughtSpot Cloud, and perform live queries to create answers and Liveboards.

--- a/cloud/modules/ROOT/pages/connections-trino-add.adoc
+++ b/cloud/modules/ROOT/pages/connections-trino-add.adoc
@@ -2,7 +2,7 @@
 :last_updated: 9/21/2020
 :linkattrs:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-add-connection.adoc
+:page-aliases:
 :experimental:
 :connection: Trino
 

--- a/cloud/modules/ROOT/pages/connections-trino-delete-table-dependencies.adoc
+++ b/cloud/modules/ROOT/pages/connections-trino-delete-table-dependencies.adoc
@@ -2,7 +2,7 @@
 :last_updated: 11/05/2021
 :linkattrs:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-delete-table-dependencies.adoc
+:page-aliases:
 :experimental:
 :connection: Trino
 

--- a/cloud/modules/ROOT/pages/connections-trino-delete-table.adoc
+++ b/cloud/modules/ROOT/pages/connections-trino-delete-table.adoc
@@ -2,7 +2,7 @@
 :last_updated: 9/21/2020
 :linkattrs:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-delete-table.adoc
+:page-aliases:
 :experimental:
 :connection: Trino
 

--- a/cloud/modules/ROOT/pages/connections-trino-delete.adoc
+++ b/cloud/modules/ROOT/pages/connections-trino-delete.adoc
@@ -3,7 +3,7 @@
 :linkattrs:
 :experimental:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-delete-connection.adoc
+:page-aliases:
 :connection: Trino
 
 A connection can be used in multiple data sources or visualizations.

--- a/cloud/modules/ROOT/pages/connections-trino-edit.adoc
+++ b/cloud/modules/ROOT/pages/connections-trino-edit.adoc
@@ -3,7 +3,7 @@
 :linkattrs:
 :experimental:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-edit-connection.adoc
+:page-aliases:
 :description: You can edit a Starburst connection to add tables and columns.
 :connection: Trino
 

--- a/cloud/modules/ROOT/pages/connections-trino-reference.adoc
+++ b/cloud/modules/ROOT/pages/connections-trino-reference.adoc
@@ -1,6 +1,6 @@
 = Connection reference for {connection}
 :last_updated: 5/11/2020
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-connection-reference.adoc, /data-integrate/embrace/embrace-starburst-reference.adoc
+:page-aliases:
 :linkattrs:
 :page-layout: default-cloud
 :experimental:

--- a/cloud/modules/ROOT/pages/connections-trino-remap.adoc
+++ b/cloud/modules/ROOT/pages/connections-trino-remap.adoc
@@ -2,7 +2,7 @@
 :last_updated: 9/21/2020
 :linkattrs:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst-remap-connection.adoc
+:page-aliases: 
 :experimental:
 :connection: Trino
 

--- a/cloud/modules/ROOT/pages/connections-trino.adoc
+++ b/cloud/modules/ROOT/pages/connections-trino.adoc
@@ -2,7 +2,7 @@
 :last_updated: 11/05/2021
 :linkattrs:
 :page-layout: default-cloud
-:page-aliases: /admin/ts-cloud/ts-cloud-embrace-starburst.adoc
+:page-aliases:
 :experimental:
 :connection: Trino
 :description: You can connect to a Trino database in ThoughtSpot Cloud, and perform live queries to create answers and Liveboards.


### PR DESCRIPTION
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>