### PR TITLE
8.8.0.cl: removed cdw icons from home page

### DIFF
--- a/cloud/modules/ROOT/pages/index.adoc
+++ b/cloud/modules/ROOT/pages/index.adoc
@@ -113,8 +113,8 @@ Find topics for the common types of ThoughtSpot users below.
     </h2>
    <ul>
         <li><a href="https://preview-thoughtspot.netlify.app/cloud/latest/connections">Connections</a></li>
-<li><img src="_images/presto_sm.png" width="20px" alt="more options menu icon" class="inline"><a href="https://preview-thoughtspot.netlify.app/cloud/latest/connections-presto">Presto <span class="badge badge-new">New!</span></a></li>
-<li><img src="_images/trino_sm.png" width="20px" alt="more options menu icon" class="inline"><a href="https://preview-thoughtspot.netlify.app/cloud/latest/connections-trino">Trino <span class="badge badge-new">New!</span></a></li>
+<li><a href="https://preview-thoughtspot.netlify.app/cloud/latest/connections-presto">Presto <span class="badge badge-new">New!</span></a></li>
+<li><a href="https://preview-thoughtspot.netlify.app/cloud/latest/connections-trino">Trino <span class="badge badge-new">New!</span></a></li>
 <li><a href="https://preview-thoughtspot.netlify.app/cloud/latest/connections-starburst-azure-ad-oauth">Starburst Azure AD OAuth <span class="badge badge-new">New!</span></a></li>
     </ul>
     </ul>


### PR DESCRIPTION
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>