### PR TITLE
8.8.0.sw: removed "release" from la notice on home page

### DIFF
--- a/software/modules/ROOT/partials/limited-availability-notice.adoc
+++ b/software/modules/ROOT/partials/limited-availability-notice.adoc
@@ -111,7 +111,7 @@ img {
 }
 </style>
 ++++
-.image:info2.svg[Inline,30] 8.8.0.sw Limited Availability release
+.image:info2.svg[Inline,30] 8.8.0.sw Limited Availability
 ****
 8.8.0.sw is a Limited Availability (LA) release provided directly to select customers to test and provide feedback directly to ThoughtSpot, ensuring the 8.8.1.sw maintenance release is customer-tested, stable, and reliable.
 


### PR DESCRIPTION
Signed-off-by: Mark <mark.plummer@thoughtspot.com>