### PR TITLE
seekwell: removed seekwell icon from home page title

### DIFF
--- a/seekwell/modules/ROOT/pages/index.adoc
+++ b/seekwell/modules/ROOT/pages/index.adoc
@@ -1,4 +1,4 @@
-= image:just-logo-black-40px.png[] SeekWell Documentation
+= SeekWell Documentation
 :page-layout: home-branch-seekwell
 
 ++++


### PR DESCRIPTION
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>