### PR TITLE
seekwell: added latest to antora yml file for algolia indexing

### DIFF
--- a/seekwell/antora.yml
+++ b/seekwell/antora.yml
@@ -1,5 +1,5 @@
 name: seekwell
 title: SeekWell
-version: ~
+version: 'latest'
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
replaced ~ with 'latest' to ensure algolia results show the version as latest.

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>