### PR TITLE
specifying that thoughtspot provides the cluster id when installing rhel with ansible

### DIFF
--- a/software/modules/ROOT/pages/rhel-install-ansible.adoc
+++ b/software/modules/ROOT/pages/rhel-install-ansible.adoc
@@ -130,7 +130,7 @@ all:
     env: {}
     ssh_private_key: <private key use for ssh>
     tarball_location: <Release tarball complete path>
-    cluster_id: <Cluster id>
+    cluster_id: <Cluster id. Provided by ThoughtSpot.>
     cluster_name: <Cluster name>
     ramdisk_size: <size of ramdisk for falcon> # The default is 50619136k (50Gb)
     # ThoughtSpot variables. Do not modify.

--- a/software/modules/ROOT/pages/rhel-restore-ansible.adoc
+++ b/software/modules/ROOT/pages/rhel-restore-ansible.adoc
@@ -41,7 +41,7 @@ all:
     groupname: <ts_service_group>
     env: {}
     ssh_private_key: <Private key for ssh>
-    cluster_id: <Cluster ID>
+    cluster_id: <Cluster ID. Provided by ThoughtSpot.>
     cluster_name: <Cluster name>
     backupdir: <location of backup>
     ramdisk_size: 50619136k


### PR DESCRIPTION


Signed-off-by: Teresa Killmond <teresa.killmond@thoughtspot.com>