### PR TITLE
8.8.1.sw: added to display name to antora.yml

### DIFF
--- a/software/antora.yml
+++ b/software/antora.yml
@@ -1,5 +1,6 @@
 name: software
 title: Software
 version: '8.8.1.sw'
+display_version: '8.8.sw'
 nav:
 - modules/ROOT/nav.adoc


### PR DESCRIPTION
To make the UI display 8.8.sw instead of 8.8.1.sw

Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>