### PR TITLE
9.2.0.cl: fixed broken support url in lifecycle page

### DIFF
--- a/cloud/modules/ROOT/pages/release-lifecycle.adoc
+++ b/cloud/modules/ROOT/pages/release-lifecycle.adoc
@@ -28,7 +28,7 @@ They are supported by ThoughtSpot and documentation is available.
 
 ****
 Early Access features are marked with [.badge.badge-early-access]#Early Access# and are disabled by default.
-You must contact your ThoughtSpot administrator or {suppor-url} to enable them.
+You must contact your ThoughtSpot administrator or {support-url} to enable them.
 ****
 
 For details on how to enable an Early Access feature, see xref:early-access-enable.adoc[].


### PR DESCRIPTION
Signed-off-by: Mark <mark.plummer@thoughtspot.com>
(cherry picked from commit f9d4a7c4ca4fe3683949d8e50fb5bd7b93f90312)