### PR TITLE
9.5.0.cl: removed sage-spec verbiage from life cycle page

### DIFF
--- a/cloud/modules/ROOT/pages/release-lifecycle.adoc
+++ b/cloud/modules/ROOT/pages/release-lifecycle.adoc
@@ -38,8 +38,6 @@ For details on how to enable an Early Access feature, see xref:early-access-enab
 
 Private Preview features are complete, and available for select customers to try before they reach GA, when they are enabled by default. Private Preview features may have documentation which is subject to change before GA.
 
-Once enabled, your ThoughtSpot administrator can grant access to Private Preview features for users in a group by assigning the *Can preview ThoughtSpot Sage* user privilege to the group. You do not need this privilege for the xref:data-modeling-visibility.adoc#automatic-synonyms[AI-generated Worksheet synonyms] feature.
-
 ****
 Private Preview features are marked with [.badge.badge-private-preview]#Private Preview# and are disabled by default.
 You must contact {support-url} to enable them.


### PR DESCRIPTION
Signed-off-by: Mark <mark.plummer@thoughtspot.com>
(cherry picked from commit b3af37a35f362b37c3c1d35d025425b97da31849)