### PR TITLE
9.6.0.cl: SCAL-175305 - update prod clust upgr 9.7.0.cl 

### DIFF
--- a/cloud/modules/ROOT/pages/schedule.adoc
+++ b/cloud/modules/ROOT/pages/schedule.adoc
@@ -37,7 +37,7 @@ This is the targeted release schedule for upcoming ThoughtSpot Cloud upgrades:
 
 |9.7.0.cl
 |October 20-26, 2023
-|October 30-November 10, 2023
+|November 3-10, 2023
 
 |9.8.0.cl
 |October 25-November 7, 2023

--- a/cloud/modules/ROOT/partials/cloud-coming-soon-release-notes.adoc
+++ b/cloud/modules/ROOT/partials/cloud-coming-soon-release-notes.adoc
@@ -59,7 +59,7 @@ img {
 ++++
 .image:cal-outline-blue.svg[Inline,25] Release 9.7.0.cl coming soon!
 ****
-ThoughtSpot plans to upgrade customer clusters starting on October 30.
+ThoughtSpot plans to upgrade customer clusters starting on November 3.
 
 See the xref:index.adoc#next-release[highlights] of the 9.7.0.cl release.
 ****

--- a/cloud/modules/ROOT/partials/cloud-coming-soon.adoc
+++ b/cloud/modules/ROOT/partials/cloud-coming-soon.adoc
@@ -1,6 +1,6 @@
 .image:cal-outline-blue.svg[Inline,25] Release 9.7.0.cl coming soon!
 ****
-ThoughtSpot plans to upgrade customer clusters starting on October 30.
+ThoughtSpot plans to upgrade customer clusters starting on November 3.
 
 See the <<next-release,highlights>> of the 9.7.0.cl release.
 ****


### PR DESCRIPTION
From Somnath Manna on the ts-cloud-ops Slack channel:
 "PROD cluster upgrade will start from 3rd Nov onwards. Before that there is no upgrade scheduled."