### PR TITLE
SCAL-189664 - deprecate spotapps

### DIFF
--- a/cloud/modules/ROOT/pages/deprecation.adoc
+++ b/cloud/modules/ROOT/pages/deprecation.adoc
@@ -1,5 +1,5 @@
 = Deprecated and removed features
-:last_updated: 2/08/2021
+:last_updated: 1/22/2024
 :linkattrs:
 :experimental:
 :page-layout: default-cloud
@@ -24,12 +24,19 @@ Use following notes above feature that is deprecated. Send a link back to this d
 NOTE: This feature is now deprecated. You may not use it starting with release 7.1. For details, see xref:deprecation.adoc[Deprecation Announcements].
 ////
 
-== Deprecated in 9.10.0.cl
+== Removed in 9.12.0.cl
 
-The 9.10.0.cl release of ThoughtSpot Cloud, targeted for February 2024 (GA), will *deprecate* the following feature. ThoughtSpot will drop support for this feature in a later release.
+The 9.12.0.cl release of ThoughtSpot Cloud, targeted for April 2024 (GA), will remove the following feature:.
 
 SpotApps::
-Beginning in the 9.10.0.cl release, you will still be able to use SpotApps, but ThoughtSpot will remove them in a subsequent release. After removal, you can download the TML files from our developer website, https://developers.thoughtspot.com/codespot?type=TML[CodeSpot^]. You can then modify (if applicable) and import these TML files into your cluster using our TML import/export utility from the data workspace.
+Beginning in the 9.12.0.cl release, you will no longer be able to use SpotApps. Alternatively, you can download the TML files from our developer website, https://developers.thoughtspot.com/codespot?type=TML[CodeSpot^]. You can then modify (if applicable) and import these TML files into your cluster using our TML import/export utility from the data workspace.
+
+== Deprecated in 9.10.0.cl
+
+The 9.10.0.cl release of ThoughtSpot Cloud, targeted for February 2024 (GA), will deprecate the following feature. ThoughtSpot will drop support for this feature in a later release.
+
+SpotApps::
+Beginning in the 9.10.0.cl release, you will still be able to use SpotApps, but ThoughtSpot will remove them in a subsequent release.
 
 == Removed in 9.8.0.cl
 


### PR DESCRIPTION
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>
(cherry picked from commit 82571c8986504e556493dc7348d3e315ea2ac5f9)