### PR TITLE
SCAL-179003 - remove custom charts from toc per manan

### DIFF
--- a/cloud/modules/ROOT/nav.adoc
+++ b/cloud/modules/ROOT/nav.adoc
@@ -536,7 +536,6 @@
 *** xref:chart-gridlines.adoc[Display gridlines]
 *** xref:chart-zoom.adoc[Zoom into chart]
 *** xref:chart-settings-advanced.adoc[Advanced chart customization settings]
-** xref:chart-byoc.adoc[Custom charts]
 * xref:formulas.adoc[Formulas]
 ** xref:formula-add.adoc[Add formula to search]
 ** xref:formula-answer-edit.adoc[View or edit formula in search]


### PR DESCRIPTION
Manan Shah
:spiral_calendar_pad: [1:23 AM](https://thoughtspot.slack.com/archives/C064AFT9C2D/p1706001781673779)
[@mark.plummer](https://thoughtspot.slack.com/team/UDUB6VA2V)
Another update we have is that Custom Charts will also not be available in [9.10.cl](http://9.10.cl/). Can we remove it from the release notes and docs for 9.10 too? Thanks for accommodating ad hoc changes