### PR TITLE
SCAL-189664 - deprecate spotapps

### DIFF
--- a/cloud/modules/ROOT/pages/deprecation.adoc
+++ b/cloud/modules/ROOT/pages/deprecation.adoc
@@ -24,20 +24,6 @@ Use following notes above feature that is deprecated. Send a link back to this d
 NOTE: This feature is now deprecated. You may not use it starting with release 7.1. For details, see xref:deprecation.adoc[Deprecation Announcements].
 ////
 
-== Removed in 9.12.0.cl
-
-The 9.12.0.cl release of ThoughtSpot Cloud, targeted for April 2024 (GA), will remove the following feature:.
-
-SpotApps::
-Beginning in the 9.12.0.cl release, you will no longer be able to use the SpotApps UI. Alternatively, you can download the TML files from our developer website, https://developers.thoughtspot.com/codespot?type=TML[CodeSpot^]. You can then modify (if applicable) and import these TML files into your cluster using our TML import/export utility from the data workspace to achieve the same result as using the original SpotApp.
-
-== Deprecated in 9.10.0.cl
-
-The 9.10.0.cl release of ThoughtSpot Cloud, targeted for February 2024 (GA), will deprecate the following feature. ThoughtSpot will drop support for this feature in a later release.
-
-SpotApps::
-Beginning in the 9.10.0.cl release, you will still be able to use SpotApps, but ThoughtSpot will remove them in a subsequent release.
-
 == Removed in 9.8.0.cl
 
 The 9.8.0.cl release of ThoughtSpot Cloud, targeted for January 2024 (GA), will remove the following feature:

--- a/cloud/modules/ROOT/pages/gcp.adoc
+++ b/cloud/modules/ROOT/pages/gcp.adoc
@@ -17,4 +17,3 @@ Certain features supported for ThoughtSpot on AWS are not available for ThoughtS
 * xref:business-continuity.adoc#high-availability[Multi-node (High Availability)]
 * xref:connections-ipsec-vpn.adoc[IPSec VPN], xref:connections-gbq-open-vpn.adoc[GBQ Open VPN] and xref:connections-synapse-open-vpn.adoc[Synapse VPN]
 * xref:spotapps.adoc[SpotApps]
-


### PR DESCRIPTION
remove deprecation info until Sumeet gives green light (per Vijay).

Vijay Venugopal (1/27/24)
  [11:25 AM](https://thoughtspot.slack.com/archives/C06EEH9RYPL/p1706383543375169)
Hey folks - quick one
Sumeet wants a formal 2 pager with the justification for deprecation and get it approved by RnD leadership before we announce.
He is in agreement with the decision but just wants a documented approval before we announce.
I will put the doc together and push for approval in the next few days but until then
[@mark.plummer](https://thoughtspot.slack.com/team/UDUB6VA2V)
 can you remove the deprecation announcement from public docs
But keep the note about no support in GCP
Wait for my green light before posting docs or sending a field announcement