### PR TITLE
updated publish date to follow prod cluster upgrade times

### DIFF
--- a/cloud/modules/ROOT/partials/cloud-coming-soon-release-notes.adoc
+++ b/cloud/modules/ROOT/partials/cloud-coming-soon-release-notes.adoc
@@ -59,7 +59,7 @@ img {
 ++++
 .image:cal-outline-blue.svg[Inline,25] Release 9.10.0.cl coming soon!
 ****
-ThoughtSpot plans to upgrade customer clusters starting on February 12.
+ThoughtSpot plans to upgrade customer clusters starting on February 14.
 
 See the xref:index.adoc#next-release[highlights] of the 9.10.0.cl release.
 ****

--- a/cloud/modules/ROOT/partials/cloud-coming-soon.adoc
+++ b/cloud/modules/ROOT/partials/cloud-coming-soon.adoc
@@ -1,6 +1,6 @@
 .image:cal-outline-blue.svg[Inline,25] Release 9.10.0.cl coming soon!
 ****
-ThoughtSpot plans to upgrade customer clusters starting on February 12.
+ThoughtSpot plans to upgrade customer clusters starting on February 14.
 
 See the <<next-release,highlights>> of the 9.10.0.cl release.
 ****


### PR DESCRIPTION
[4:18 AM](https://thoughtspot.slack.com/archives/C01E676A16F/p1707308326558239)
We have scheduled the upgrade of clusters in the TSA_PROD_US slot to 9.10.0.cl-188. The upgrade will start at 02/14/2024 2:00 AM UTC