### PR TITLE
SCAL-201639 - adv cond formatting pushed out of release

### DIFF
--- a/cloud/modules/ROOT/partials/whats-new-9-12-0-cl.adoc
+++ b/cloud/modules/ROOT/partials/whats-new-9-12-0-cl.adoc
@@ -68,37 +68,6 @@ endif::free-trial-feature[]
 
 ifndef::free-trial-feature[]
 ifndef::pendo-links[]
-[#9-10-0-cl-conditional]
-[discrete]
-=== Advanced conditional formatting [.badge.badge-early-access]#Early Access#
-endif::[]
-ifdef::pendo-links[]
-[#9-10-0-cl-conditional]
-[discrete]
-=== Advanced conditional formatting [.badge.badge-early-access-whats-new]#Early Access#
-endif::[]
-
-// Naomi -- scal-177005. documentation JIRA scal- (approved). is it visualization as well as table? moved to 9.12.0.cl. change "compare" to "visually highlight the differences/ threshold..." in the first sentence.
-
-// PM: Manan
-
-In addition to using conditional formatting to visually highlight a threshold in a measure (for example, `sales > 10000`), you can now use conditional formatting to compare a column's measures to another column or to a parameter. For example, if you search for `sales this year` compared to `sales last year`, you can highlight where sales this year were less than last year. You can set multiple conditional formatting rules to a single table. To enable this feature, contact your administrator.
-////
-For more information, see
-ifndef::pendo-links[]
-xref:search-conditional-formatting.adoc#advanced-conditional-formatting[Advanced conditional formatting].
-endif::[]
-ifdef::pendo-links[]
-xref:search-conditional-formatting.adoc#advanced-conditional-formatting[Advanced conditional formatting,window=_blank].
-endif::[]
-////
-image::advanced-conditional-formatting.gif[Advanced conditional formatting comparing sales of state to sales of region]
-endif::free-trial-feature[]
-
-
-
-ifndef::free-trial-feature[]
-ifndef::pendo-links[]
 [#9-12-0-cl-forecasting]
 [discrete]
 === Forecasting [.badge.badge-beta]#Beta#
@@ -116,10 +85,6 @@ You can now use SpotIQ analysis to forecast future trends for your KPIs. Thought
 image::forecasting-zoom.gif[Forecasting]
 
 endif::free-trial-feature[]
-
-
-
-
 
 [#9-12-0-cl-sage-coach]
 [discrete]


### PR DESCRIPTION
per directive from Manan:

Hello everyone, I wanted to make an announcement regarding the launch of the feature ‘[Advanced conditional formatting](https://thoughtspot.atlassian.net/browse/SCAL-177005)’. We had earlier announced that it’ll be available as Early Access in 9.12.0cl, but unfortunately we’ll have to roll it back for the release.
Charts team has been working hard on releasing a lot of big ticket features at a quick pace for the past few releases, and it has made us vulnerable to more incoming issues given the large surface area. In the last couple of months, the team has been riddled with a lot of high priority issues and regressions which need to be taken up before we can proceed with the development of new features. Quality is the number one priority