### PR TITLE
fixed missing link to sage search page

### DIFF
--- a/cloud/modules/ROOT/pages/search.adoc
+++ b/cloud/modules/ROOT/pages/search.adoc
@@ -1,5 +1,5 @@
-= Search Overview
-:last_updated: 11/05/2021
+= Search
+:last_updated: 5/24/2024
 :description: With ThoughtSpot, apply intuitive and powerful relational search to get insights from existing answers and Liveboards, or directly from data sources.
 :page-aliases: /end-user/search/search-overview.adoc
 :page-layout: default-cloud
@@ -10,7 +10,8 @@
 
 Using ThoughtSpot's relational search is intuitive. In the search bar, type what you are interested in exploring, and ThoughtSpot returns a set of results in the form of a table or a chart. We call this set of results in response to a search an Answer.
 
-ThoughtSpot has two primary search mechanisms:
+ThoughtSpot has the following search capabilities:
 
-. xref:search-answers.adoc[Search Answers and Liveboards]
-. xref:search-data.adoc[Search Data]
+- xref:search-answers.adoc[Search Answers and Liveboards]
+- xref:search-data.adoc[Search Data]
+- xref:search-sage.adoc[ThoughtSpot Sage]


### PR DESCRIPTION
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>
(cherry picked from commit c7828c437952a95f6cca5804ec791a245df46b1c)