### PR TITLE
SCAL-205511 - remove Cannot copy or edit existing Liveboards

### DIFF
--- a/cloud/modules/ROOT/pages/privileges-end-user.adoc
+++ b/cloud/modules/ROOT/pages/privileges-end-user.adoc
@@ -1,11 +1,11 @@
 = Understanding privileges
-:last_updated: 5/28/2024
+:last_updated: 8/24/2024
 :linkattrs:
 :experimental:
 :page-layout: default-cloud
 :page-aliases: /end-user/introduction/about-privileges-end-user.adoc
 :description: The things you can do in ThoughtSpot are determined by the privileges you have. Privileges are granted through group membership.
-:jira: SCAL-209169, SCAL-214359
+:jira: SCAL-209169, SCAL-214359, SCAL-205511
 
 
 

--- a/cloud/modules/ROOT/partials/privileges.adoc
+++ b/cloud/modules/ROOT/partials/privileges.adoc
@@ -51,12 +51,3 @@ Users in groups with this privilege (directly or through group inheritance):
 Your installation configuration may enable or disable the availability of this privilege. By default, it is enabled. Administrators or groups with the privilege *Can administer ThoughtSpot* can grant this privilege.
 
 Has Developer privilege:: Can access and use the ThoughtSpot Developer Portal to explore the ThoughtSpot APIs and developer tools, and build web applications with ThoughtSpot content.
-
-[#read-only]
-Cannot copy or edit existing Liveboards:: Users are limited to viewing and exploring curated Liveboards (and Answers). They cannot copy, edit, download, or share them.
-+
-This privilege is designed to support embedded implementations, and is not available by default. Contact {support-url} to enable it.
-+
-See xref:liveboard-granular-permission.adoc[Granular access to Liveboards] for a deeper discussion of this privilege, and an implementation example.
-+
-NOTE: This privilege is now deprecated. It is unavailable if you are using the xref:answer-experience-new.adoc[new Answer experience]. To use this privilege, return to the classic Answer experience. For details, see xref:deprecation.adoc[Deprecation announcements].


### PR DESCRIPTION
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>
(cherry picked from commit 1b18675f33632a15db134ef77fc8265dd2df0023)