### PR TITLE
SCAL-202635 - remove dep note from gran acc to liveboards

### DIFF
--- a/cloud/modules/ROOT/pages/liveboard-granular-permission.adoc
+++ b/cloud/modules/ROOT/pages/liveboard-granular-permission.adoc
@@ -1,10 +1,11 @@
 = Granular access to Liveboards
-:last_updated: 2/16/2022
+:last_updated: 8/29/2024
 :linkattrs:
 :experimental:
 :page-layout: default-cloud
 :page-aliases: /end-user/introduction/pinboard-granular-permission.adoc
 :description: You can limit some users to Read only access on curated Liveboards. These users can view and explore; however, they cannot copy, alter, download, or share.
+:jira: SCAL-202635
 
 ThoughtSpot has a user privilege that prevents certain users from creating or modifying Liveboards.
 
@@ -20,8 +21,6 @@ These users _cannot_ perform the following actions that are otherwise available 
 * Edit
 * Copy and edit
 * Copy embed link
-
-NOTE: This feature is now deprecated. It is unavailable if you are using the xref:answer-experience-new.adoc[new Answer experience]. To use this feature, return to the classic Answer experience. For details, see xref:deprecation.adoc[Deprecation Announcements].
 
 == How to limit access to Liveboards
 


### PR DESCRIPTION
Signed-off-by: Mark Plummer <mark.plummer@thoughtspot.com>
(cherry picked from commit a4f4fdd16601e3b317e77889269b208c302ebef2)