### PR TITLE
copying excel plugin to 10.3

### DIFF
--- a/cloud/modules/ROOT/nav.adoc
+++ b/cloud/modules/ROOT/nav.adoc
@@ -53,6 +53,7 @@
 **** xref:sync-zoho.adoc[Sync data to Zoho]
 *** xref:privileges-end-user.adoc[Privileges]
 *** xref:thoughtspot-sheets.adoc[Google Sheets add-on]
+*** xref:thoughtspot-excel.adoc[ThoughtSpot plugin for MS Excel]
 *** xref:thoughtspot-slides.adoc[Google Slides add-on]
 *** xref:spotdev.adoc[ThoughtSpot Dev Slack app]
 ** xref:analyst.adoc[Analysts]

--- a/cloud/modules/ROOT/pages/thoughtspot-excel.adoc
+++ b/cloud/modules/ROOT/pages/thoughtspot-excel.adoc
@@ -1,0 +1,73 @@
+= ThoughtSpot add-in for Microsoft Excel
+:last_updated: 9/16/2024
+:linkattrs:
+:experimental:
+:author: rani
+:page-layout: default-cloud
+:page-aliases:
+:description: Learn about the ThoughtSpot add-on for Google Sheets.
+:jira: SCAL-224481
+
+++++
+<style>
+iframe {
+    width: 498px !important;
+    height: 280px !important;
+    border-width: 0;
+}
+</style>
+++++
+
+ThoughtSpot plugin for Microsoft Excel(TM) is an add-on that allows you to connect to a ThoughtSpot instance, and pull data directly into a Excel sheet from trusted data sources connected to that instance (like Snowflake, Google BigQuery, Databricks, and others) for ad-hoc analysis.
+
+[.bordered]
+image::excel-plugin.png[A MS excel sheet displaying the ThoughtSpot plugin in the top bar]
+
+== Details
+
+- Requires a ThoughtSpot license and an email linked to a ThoughtSpot user ID.
+- Requires the `Can download data` privilege in ThoughtSpot to use this add-in.
+- Currently available for Windows devices and SaaS versions of MS Excel.
+- You can sign up for a ThoughtSpot free trial account to use this add-in.
+- Only compatible with ThoughtSpot Cloud.
+
+== Setup
+
+NOTE: Contact {support-url} for assistance on the first time configuration of the security settings.
+
+. Open Excel. To download the plugin, Select *Insert* > *Add-ins* > *Get Add-ins* > which brings up the Office Add-ins window, and search for ThoughtSpot, which will then show *ThoughtSpot Analytics* in the list.
+. Click *Add* to download.
++
+[.bordered]
+image::excel-plugin5.png[Click Add to download]
++
+Upon clicking *Add* you will receive a pop-up with the license agreement. Click *agree to all above terms & conditions* to proceed.
+. Open a new Excel sheet and navigate to *Home* > *ThoughtSpot Analytics*.
++
+The _Connect to ThoughtSpot_ window opens.
+. Enter the URL of your *ThoughtSpot instance* or click the *free trial* link if you do not have an instance.
++
+If you chose the free trial option, you'll come back to this page after you sign up and enter your free trial instance.
++
+[.bordered]
+image::excel-plugin1.png[Enter the url for your TS instance]
++
+. Click *Connect*.
+. Sign in to your ThoughtSpot instance using your ThoughtSpot username and password or SSO.
++
+. Choose the ThoughtSpot worksheet you want to work with, from *Data* > *Sources* > *Choose sources*.
++
+[.bordered]
+image::excel-plugin2.png[Click on Choose sources for selecting the relevant worksheet]
++
+. Select the column(s) you want to move into the Excel sheet, and the click *Add columns* > *Get data*.
++
+. You can add the column(s) to a new Excel sheet or the current Excel sheet. This will bring all selected data from the data warehouse into your Excel sheet.
++
+[.bordered]
+image::excel-plugin3.png[Click on Choose sources for selecting the relevant worksheet]
++
+Your selected data is now in Excel.
+
+
+


### PR DESCRIPTION
This edit which was made for 10.1.0.cl didnt appear on 10.3 docs upon publishing. 
Copied the thoughtspot-excel.adoc file to the set of 10.3 files, and edited the existing 10.3 nav.adoc file.