### PR TITLE
removed .bordered css for custom chart image and removed 2nd one

### DIFF
--- a/cloud/modules/ROOT/partials/whats-new-10-5-0-cl.adoc
+++ b/cloud/modules/ROOT/partials/whats-new-10-5-0-cl.adoc
@@ -165,7 +165,6 @@ endif::[]
 
 Custom charts allow you to use charts created outside of ThoughtSpot, including from third-party chart libraries. To enable this feature, contact your administrator.
 
-[.bordered]
 image::custom-chart-select.png[Gauge chart]
 endif::free-trial-feature[]
 
@@ -353,8 +352,6 @@ endif::[]
 
 Administrators can now enable custom charts on the *Admin > All Orgs > Early access features* page.
 
-[.bordered]
-image::custom-chart-select.png[Gauge chart]
 endif::free-trial-feature[]
 
 ifndef::free-trial-feature[]


### PR DESCRIPTION
in the 10.5.0.cl

removed bordered css because the gauge chart image already has a baked-in drop shadow.