### PR TITLE
removed URL sharing - per-org URL from WN & RN as it won't GA in 10.6…

### DIFF
--- a/cloud/modules/ROOT/pages/orgs-overview.adoc
+++ b/cloud/modules/ROOT/pages/orgs-overview.adoc
@@ -81,8 +81,9 @@ image::org-switcher-gif.gif[Switch the Org]
 
 include::partial$all-org-scope.adoc[]
 
-== Org context for sharing links
 
+.Org context for sharing links [.badge.badge-early-access]#Early Access#
+****
 URLs in emails now include Org context with query parameters in the URL that indicate the Org ID so that users are taken directly to the correct Liveboard in the correct Org even if they belong to multiple Orgs. Links generated for the following include Org context with query parameters:
 
 * Sharing
@@ -107,7 +108,7 @@ To enable this feature:
 . Next to *Org Url sharing*, click *Edit*.
 . On the *Org Url sharing* page, toggle to select *Enabled* or *Disabled* and click *Save*.
 
-
+****
 
 
 == Manage users and groups

--- a/cloud/modules/ROOT/partials/new-features-cloud-release.adoc
+++ b/cloud/modules/ROOT/partials/new-features-cloud-release.adoc
@@ -187,11 +187,14 @@ Learnability in conversation: feedback generation in follow-up questions:: You c
 +
 For more information, see xref:spotter-getting-started.adoc#learnability[Coach Spotter within a conversation].
 
+////
 // Mary. jira: SCAL-232495. docs jira: SCAL-232812
 Org context for sharing links::
 ThoughtSpot's org context for sharing links is now available to all users and enabled by default. URLs in emails now include Org context so that users are taken directly to the correct Liveboard in the correct Org even if they belong to multiple Orgs. You can also move between different browser tabs that point to different Orgs. To enable this feature, contact your administrator.
 +
 For more information, see xref:orgs-overview.adoc[Org context for sharing links].
+//Removed from 10.6.0.cl GA remains EA pending a dependency from TSE.
+////
 
 // Mary. jira: SCAL-216546. docs jira: SCAL-220685
 Import and export users and groups using TML [.badge.badge-early-access-relnotes]#Early Access#::

--- a/cloud/modules/ROOT/partials/whats-new-10-6-0-cl.adoc
+++ b/cloud/modules/ROOT/partials/whats-new-10-6-0-cl.adoc
@@ -727,6 +727,7 @@ endif::free-trial-feature[]
 // PM: ?. no docs needed?
 ////
 
+////
 [#10-6-0-cl-url]
 [discrete]
 === Org context for sharing links
@@ -735,10 +736,12 @@ ThoughtSpot's org context for sharing links is now available to all users and en
 For more information, see xref:orgs-overview.adoc[Org context for sharing links].
 
 
-
 // Mary. jira: SCAL-232495. docs jira: SCAL-232812
 // PM: Aashica - PM approved
 // Enable in Admin > Application settings > Administration. Under Org Url sharing, click Edit and toggle Enabled/Disabled.
+//updated to remove from 10.6.0.cl as GA is delayed pending a TSE dependency.
+////
+
 
 ifndef::free-trial-feature[]
 [discrete]


### PR DESCRIPTION
….0.cl. Added back EA badge to associated topic.