### PR TITLE
[docs-sync draft] AgentSpot Aug 6→Aug 10 (6face0a0680c) — web search, Opus 5, workflow sharing

### DIFF
--- a/agentspot/modules/ROOT/pages/agentspot-create-agent.adoc
+++ b/agentspot/modules/ROOT/pages/agentspot-create-agent.adoc
@@ -49,6 +49,10 @@ Adding a model allows your agent to work with large structured data sets — a k
 Some skills are pre-populated; you can add your own.
 * *Files*: documents you want your agent to have in context to help you with your work. Supports documents, spreadsheets, PDF, and images (TXT, MD, PDF, DOCX, PPTX, XLSX, XLSM, CSV, TSV, JSON, YAML, HTML, XML, PNG, JPG, WEBP, GIF).
 
+// auto-draft PR#1840 — REVIEW
+// TODO image: Tools panel in the builder side panel with web search enabled
+NOTE: Agents can be given *controlled* access to web search, so an agent can pull in current information from the web when a task needs it. Web search runs under a defined policy rather than being open-ended. Check the *Tools* in the builder side panel to see whether web search is enabled for an agent.
+
 [TIP]
 .Tips for writing effective prompts
 ====
@@ -82,6 +86,9 @@ For details on each component, see <<agent-components,Agent components>>.
 
 NOTE: After saving, AgentSpot exits the builder and opens your agent with a set of suggested conversation starters.
 Test a few conversations before sharing — you can return to edit mode at any time and refine the instructions based on how the agent performs.
+
+// auto-draft PR#1831 — REVIEW
+NOTE: New agents are created with Claude Opus 5 as the default model. Existing agents are unaffected.
 
 == Step 3: Share the agent
 

--- a/agentspot/modules/ROOT/pages/agentspot-create-workflow.adoc
+++ b/agentspot/modules/ROOT/pages/agentspot-create-workflow.adoc
@@ -98,6 +98,14 @@ The builder reopens with the full history of your previous conversation.
 
 TIP: Expect to iterate. It typically takes a few refinement cycles to get a workflow producing exactly the output you want.
 
+// auto-draft PR#1515 — REVIEW
+// TODO image: the "share as prompt" flow in the workflow view
+=== Sharing and liking workflows
+
+You can share a workflow as a *prompt*. Instead of sending a static copy, the recipient rebuilds the workflow in place from the shared prompt — they get a working workflow they can then adjust for themselves.
+
+You can also *like* a workflow to signal the ones your team finds most useful.
+
 === Workflow templates
 
 If you want inspiration for workflows to build, template examples are available on the AgentSpot website.

--- a/agentspot/modules/ROOT/pages/agentspot-use-agent.adoc
+++ b/agentspot/modules/ROOT/pages/agentspot-use-agent.adoc
@@ -25,6 +25,10 @@ TIP: To see if it is right agent for you, ask the agent itself.
 . Ask follow-up questions in the same conversation. (The agent remembers earlier messages)
 . (Optional) upload a file to use with your questions, by clicking the image:plus.svg[plus] button in the chat box or dragging and dropping the file into the chat.
 
+// auto-draft PR#1824 — REVIEW
+// TODO image: the credit confirmation dialog shown on send
+NOTE: When you resume a conversation and send a message that consumes credits, AgentSpot confirms the credit use before sending. This confirmation appears once per browser, so it does not interrupt every message.
+
 == Ask good questions
 
 The single biggest factor in answer quality is your question.

--- a/agentspot/release-notes-src/CHANGELOG.md
+++ b/agentspot/release-notes-src/CHANGELOG.md
@@ -1,0 +1,12 @@
+# AgentSpot Changelog
+
+## 2026-08-10 — d8f4037908e7..6face0a0680c
+
+- Paginate the SRE tenants list so tenants past 100 are visible (SCAL-331050) · `0bca3bb7aa5d` · SCAL-331050 · [#1841](https://github.com/thoughtspot/agentspot/pull/1841)
+- Give Agent Builder controlled web search access (SCAL-331060) · `af6441038a2b` · SCAL-331060 · [#1840](https://github.com/thoughtspot/agentspot/pull/1840)
+- Scale the data tier: Cloud SQL 8 vCPU / 32 GiB, Redis 4 GiB + volatile-lru, DB alerts (SCAL-327431, SCAL-327432) · `069617640af6` · SCAL-327431, SCAL-327432 · [#1779](https://github.com/thoughtspot/agentspot/pull/1779)
+- Default the AgentSpot creation model to Claude Opus 5 (SCAL-330700) · `09424a2c32c1` · SCAL-330700 · [#1831](https://github.com/thoughtspot/agentspot/pull/1831)
+- Gate the runtime MCP direct-host tunnel on a Vertex-runtime signal, not on RUNTIME_CONFIG_CONNECT_HOST (SCAL-330583) · `fffeb98bab4a` · SCAL-330583 · [#1826](https://github.com/thoughtspot/agentspot/pull/1826)
+- Confirm resume Do Credit on send, once per browser (SCAL-330313) · `a64f46530f52` · SCAL-330313 · [#1824](https://github.com/thoughtspot/agentspot/pull/1824)
+- fix(intercom): fail-closed, tenant-scoped identity + messenger lifecycle (SCAL-330156) · `09a0bfb09f02` · SCAL-330156 · [#1822](https://github.com/thoughtspot/agentspot/pull/1822)
+- Prompt-based workflow sharing: rebuild in place from a shared prompt, plus workflow likes (SCAL-323720) · `845c358d374a` · SCAL-323720, SCAL-322820 · [#1515](https://github.com/thoughtspot/agentspot/pull/1515)

--- a/agentspot/release-notes-src/notes.md
+++ b/agentspot/release-notes-src/notes.md
@@ -1,0 +1,40 @@
+# AgentSpot — What's New (draft)
+
+<!-- auto-draft — REVIEW: internal handoff notes generated from staging range
+d8f4037908e7..6face0a0680c. Humanized companion to CHANGELOG.md. Verify wording,
+capture the suggested screenshots, then fold into the feature pages. Not published
+(AgentSpot is Preview — no release-notes page yet). -->
+
+## Controlled web search for agents — PR#1840 (SCAL-331060)
+Agent Builder can now grant an agent controlled access to web search, so agents can pull in
+current information from the web when a task needs it, under a defined policy rather than
+open-ended. → folded into `agentspot-create-agent.adoc`.
+_image: Tools panel with web search enabled_
+
+## Claude Opus 5 is the default creation model — PR#1831 (SCAL-330700)
+New agents and workflows are created with Claude Opus 5 by default; existing agents are
+unaffected. → folded into `agentspot-create-agent.adoc`.
+
+## Credit confirmation when resuming a conversation — PR#1824 (SCAL-330313)
+Resuming a conversation and sending a credit-consuming message now confirms the credit use
+first, shown once per browser. → folded into `agentspot-use-agent.adoc`.
+_image: the credit confirmation dialog shown on send_
+
+## Share workflows from a prompt, and like workflows — PR#1515 (SCAL-323720)
+Workflows can be shared as a prompt (recipient rebuilds in place rather than getting a static
+copy), and workflows can be liked. → folded into `agentspot-create-workflow.adoc`.
+_image: sharing a workflow as a prompt_
+
+## Considered, not documented
+
+Changes in this range that were **not** written up. Promote any of these if you disagree.
+
+- **In-app support messaging (Intercom identity)** — PR#1822 (SCAL-330156). Fail-closed,
+  tenant-scoped support-widget identity. Judged internal groundwork — but a human may choose to
+  tease it as a forthcoming capability.
+- **SRE tenants list pagination** — PR#1841 (SCAL-331050). Internal SRE/admin tool, not
+  customer-facing.
+- **Data-tier scaling** — PR#1779 (SCAL-327431, SCAL-327432). Cloud SQL / Redis capacity; infra,
+  no user-visible behavior.
+- **Runtime MCP tunnel gating** — PR#1826 (SCAL-330583). Runtime plumbing; not user-facing.
+- Plus the remaining infra/CI/test-only commits in this range (see `CHANGELOG.md`).


### PR DESCRIPTION
> ⚠️ **Automated draft — do not merge as-is.** Generated by the AgentSpot docs-sync automation (SCAL-330555) from the staging range `d8f4037908e7..6face0a0680c` (Aug 6 → Aug 10). Every machine edit is marked `// auto-draft … REVIEW`. An AgentSpot engineer verifies, then the docs team edits/captures screenshots and merges.

## What changed

**Feature pages (published on merge — text-only, need review):**
- `agentspot-create-agent.adoc` — controlled web search for agents; Claude Opus 5 as the default creation model.
- `agentspot-use-agent.adoc` — credit confirmation when resuming a conversation.
- `agentspot-create-workflow.adoc` — share workflows as a prompt + like workflows.

**Internal handoff (not published — `release-notes-src/`, Antora ignores it):**
- `CHANGELOG.md` — deterministic record of user-facing PRs in the range.
- `notes.md` — humanized digest + a **"Considered, not documented"** list.

## Screenshots needed (`// TODO image:`)
- Tools panel with web search enabled (create-agent)
- credit confirmation dialog (use-agent)
- sharing a workflow as a prompt (create-workflow)

## Considered, not documented (promote if you disagree)
- In-app support messaging (Intercom identity) — PR#1822 — judged internal groundwork.
- SRE tenants-list pagination — PR#1841 — internal SRE tool.
- Data-tier scaling — PR#1779 — infra, no user-visible behavior.
- Runtime MCP tunnel gating — PR#1826 — runtime plumbing.

No release-notes page is added (AgentSpot is Preview). Prose is hedged where UI labels weren't certain from the diff — verify against the product.
